### PR TITLE
More adaptive columns in RuleList

### DIFF
--- a/src/components/LinkedRuleIndexList.astro
+++ b/src/components/LinkedRuleIndexList.astro
@@ -25,7 +25,7 @@ const filteredBookData = bookData.filter((book) => !book.path.endsWith("pm"));
           class="mt-4 mb-8 lg:my-11 bg-neutral-200 bg-opacity-30 p-6 rounded-xl"
         >
           <H3>{schoolName + " " + bookName}</H3>
-          <ul class="my-4 text-xl text-neutral-800 columns-2 xl:columns-3 gap-8">
+          <ul class="my-4 text-xl text-neutral-800 columns-3xs gap-8">
             {data.map((rule) => {
               const { rule_class, rule_no, book } = rule;
               const booktitle = book.split(" ");


### PR DESCRIPTION
The previous column css would use 2 columns even on very narrow screens. Using the `columns-3xs` utility instead ensures that 3, 2 or 1 columns can be used based on the size of the screen, making this component more mobile-friendly:

## Before

![Screenshot from 2024-11-02 21-20-24](https://github.com/user-attachments/assets/e024e320-29c7-4148-b78f-2babf984f6b2)

## After

![Screenshot from 2024-11-02 21-20-30](https://github.com/user-attachments/assets/9648c6b7-6bd3-4a91-94da-9ae5d7b7d10d)


